### PR TITLE
edit sac-cli clean command to only drop dbs with "sac_test_" prefix

### DIFF
--- a/cli/commands/clean_tests.go
+++ b/cli/commands/clean_tests.go
@@ -48,7 +48,7 @@ func CleanTestDBs() error {
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
 
-	rows, err := db.Query("SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres' AND datname != $1 AND datname != $2", currentUser.Username, CONFIG.Database.DatabaseName)
+	rows, err := db.Query("SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres' AND datname != $1 AND datname != $2 AND datname LIKE 'sac_test_%';", currentUser.Username, CONFIG.Database.DatabaseName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

edit sac-cli clean command to only drop dbs with "sac_test_" prefix

Please include a summary of the changes and the related issue. Please also
include relevant motivation, context, and images!

# How Has This Been Tested?

it works, trust

# Checklist

- [x ] I have performed a self-review of my code
- [x ] I have reached out to another developer to review my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

<!-- Easter Egg -->