### PR TITLE
unauthorized when you have no cookies

### DIFF
--- a/backend/src/middleware/auth.go
+++ b/backend/src/middleware/auth.go
@@ -67,6 +67,10 @@ func (m *MiddlewareService) Authorize(requiredPermissions ...auth.Permission) fu
 			return c.Next()
 		}
 
+		if c.Cookies("access_token") == "" || c.Cookies("refresh_token") == "" {
+			return errors.Unauthorized.FiberError(c)
+		}
+
 		role, err := auth.GetRoleFromToken(c.Cookies("access_token"), m.AuthSettings.AccessKey)
 		if err != nil {
 			return errors.FailedToParseAccessToken.FiberError(c)


### PR DESCRIPTION
throws unauthorized rather than failed to parse access token when trying to make a request and is not logged in