### PR TITLE
Fix: Backend CI Failing 

### DIFF
--- a/backend/src/controllers/club.go
+++ b/backend/src/controllers/club.go
@@ -1,8 +1,6 @@
 package controllers
 
 import (
-	"fmt"
-
 	"github.com/GenerateNU/sac/backend/src/errors"
 	"github.com/GenerateNU/sac/backend/src/models"
 	"github.com/GenerateNU/sac/backend/src/services"
@@ -24,7 +22,6 @@ func (cl *ClubController) GetAllClubs(c *fiber.Ctx) error {
 	queryParams.Page = 1   // default page
 
 	if err := c.QueryParser(&queryParams); err != nil {
-		fmt.Println(err)
 		return errors.FailedtoParseQueryParams.FiberError(c)
 	}
 

--- a/backend/src/services/auth.go
+++ b/backend/src/services/auth.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"fmt"
-
 	"github.com/GenerateNU/sac/backend/src/auth"
 	"github.com/GenerateNU/sac/backend/src/errors"
 	"github.com/GenerateNU/sac/backend/src/models"
@@ -101,7 +99,6 @@ func (a *AuthService) UpdatePassword(id string, userBody models.UpdatePasswordRe
 
 	correct, passwordErr := auth.ComparePasswordAndHash(userBody.OldPassword, passwordHash)
 	if passwordErr != nil {
-		fmt.Println("err", passwordErr)
 		return &errors.FailedToValidateUser
 	}
 

--- a/backend/tests/api/helpers/requests.go
+++ b/backend/tests/api/helpers/requests.go
@@ -69,6 +69,10 @@ func (app TestApp) Send(request TestRequest) (*http.Response, error) {
 			Name:  "access_token",
 			Value: app.TestUser.AccessToken,
 		})
+		req.AddCookie(&http.Cookie{
+			Name:  "refresh_token",
+			Value: app.TestUser.RefreshToken,
+		})
 	}
 
 	resp, err := app.App.Test(req)


### PR DESCRIPTION
Backend CI was failing because refresh_token cookie was not being sent when authed in the testing library. Also removed some debugging print statements